### PR TITLE
#13 source de tipos de documento editable

### DIFF
--- a/Block/Adminhtml/Order/View/CidFields.php
+++ b/Block/Adminhtml/Order/View/CidFields.php
@@ -1,0 +1,30 @@
+<?php
+namespace Mugar\CustomerIdentificationDocument\Block\Adminhtml\Order\View;
+
+use Mugar\CustomerIdentificationDocument\Api\CidFieldsRepositoryInterface;
+
+class CidFields extends \Magento\Sales\Block\Adminhtml\Order\AbstractOrder
+{
+    /**
+     * ContactType constructor.
+     * @param \Magento\Backend\Block\Template\Context $context
+     * @param \Magento\Framework\Registry $registry
+     * @param \Magento\Sales\Helper\Admin $adminHelper
+     * @param array $data
+     */
+    public function __construct(
+        \Magento\Backend\Block\Template\Context $context,
+        \Magento\Framework\Registry $registry,
+        \Magento\Sales\Helper\Admin $adminHelper,
+        CidFieldsRepositoryInterface $cidFieldsRepository,
+        array $data = []
+    ) {
+        $this->cidFieldsRepository = $cidFieldsRepository;
+        parent::__construct($context, $registry, $adminHelper, $data);
+    }
+
+    public function getCidFields()
+    {
+        return $this->cidFieldsRepository->getCidFields($this->getOrder());
+    }
+}

--- a/Block/Order/View/CidFields.php
+++ b/Block/Order/View/CidFields.php
@@ -9,7 +9,7 @@
  *
  */
 
-namespace Mugar\CustomerIdentificationDocument\Block\Order;
+namespace Mugar\CustomerIdentificationDocument\Block\Order\View;
 
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -12,11 +12,12 @@
 namespace Mugar\CustomerIdentificationDocument\Helper;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Store\Model\ScopeInterface;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Mugar\CustomerIdentificationDocument\Model\Config\Source\Types;
 
 /**
  * Helper to get system config
@@ -32,6 +33,8 @@ class Data extends AbstractHelper
 {
     const SHIPPING_ENABLED = 'checkout/cid/shipping_enabled';
     const BILLING_ENABLED = 'checkout/cid/billing_enabled';
+    const SHIPPING_DOCUMENT_TYPES = 'checkout/cid/shipping_types';
+    const BILLING_DOCUMENT_TYPES = 'checkout/cid/billing_types';
 
     /**
      * Magento\Framework\App\Config\ScopeConfigInterface
@@ -45,6 +48,8 @@ class Data extends AbstractHelper
      */
     private $_storeManager;
 
+    private $_types;
+
     /**
      * Data constructor.
      * @param Context $context
@@ -54,11 +59,13 @@ class Data extends AbstractHelper
     public function __construct(
         Context $context,
         ScopeConfigInterface $scopeConfigInterface,
-        StoreManagerInterface $storeManagerInterface
+        StoreManagerInterface $storeManagerInterface,
+        Types $types
     ) {
         parent::__construct($context);
         $this->_scopeConfig = $scopeConfigInterface;
         $this->_storeManager = $storeManagerInterface;
+        $this->_types = $types;
     }
 
     /**
@@ -85,6 +92,52 @@ class Data extends AbstractHelper
     {
         $storeId = is_null($store) ? $this->getStoreId() : $store->getId();
         return $this->getConfigValue(self::BILLING_ENABLED, $storeId);
+    }
+
+    /**
+     * get Shipping Document Types
+     *
+     * @param null $store
+     * @return mixed
+     * @throws NoSuchEntityException
+     */
+    public function getShippingDocumentTypes($store = null)
+    {
+        $optionsSelected = [];
+        $storeId = is_null($store) ? $this->getStoreId() : $store->getId();
+        $options = $this->_types->toOptionArray();
+        $systemOptionsSelected = explode(',', $this->getConfigValue(self::SHIPPING_DOCUMENT_TYPES, $storeId));
+
+        foreach ($options as $option) {
+            if (in_array($option['value'], $systemOptionsSelected)) {
+                $optionsSelected[$option['value']] = $option['label']->getText();
+            }
+        }
+
+        return $optionsSelected;
+    }
+
+    /**
+     * get Shipping Document Types
+     *
+     * @param null $store
+     * @return mixed
+     * @throws NoSuchEntityException
+     */
+    public function getBillingDocumentTypes($store = null)
+    {
+        $optionsSelected = [];
+        $storeId = is_null($store) ? $this->getStoreId() : $store->getId();
+        $options = $this->_types->toOptionArray();
+        $systemOptionsSelected = explode(',', $this->getConfigValue(self::BILLING_DOCUMENT_TYPES, $storeId));
+
+        foreach ($options as $option) {
+            if (in_array($option['value'], $systemOptionsSelected)) {
+                $optionsSelected[$option['value']] = $option['label']->getText();
+            }
+        }
+
+        return $optionsSelected;
     }
 
     /**

--- a/Model/Config/Source/Types.php
+++ b/Model/Config/Source/Types.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Mugar\CustomerIdentificationDocument\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class Types implements OptionSourceInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @codeCoverageIgnore
+     */
+    public function toOptionArray()
+    {
+        return [
+            ['value' => 1, 'label' => __('DNI')],
+            ['value' => 2, 'label' => __('CI')],
+            ['value' => 3, 'label' => __('Passport')]
+        ];
+    }
+}

--- a/Plugin/CidConfiguration.php
+++ b/Plugin/CidConfiguration.php
@@ -12,10 +12,10 @@
 namespace Mugar\CustomerIdentificationDocument\Plugin;
 
 use Magento\Checkout\Block\Checkout\LayoutProcessor;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Mugar\CustomerIdentificationDocument\Helper\Data;
 
-class CidConfiguration {
+class CidConfiguration
+{
 
     /**
      * Mugar\CustomerIdentificationDocument\Helper\Data
@@ -36,7 +36,11 @@ class CidConfiguration {
     public function afterProcess(
         LayoutProcessor $processor,
         array $jsLayout
-    ){
+    ) {
+        $writer = new \Zend\Log\Writer\Stream(BP . '/var/log/oliverio.log');
+        $logger = new \Zend\Log\Logger();
+        $logger->addWriter($writer);
+
         if (!$this->helper->isShippingEnabled()) {
             $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']
             ['shippingAddress']['children']['cid-shipping-form']['config']['componentDisabled'] = true;
@@ -47,6 +51,20 @@ class CidConfiguration {
             ['payment']['children']['cid-billing-form']['config']['componentDisabled'] = true;
         }
 
+        $currentOptions = $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']
+        ['shippingAddress']['children']['cid-shipping-form']['children']['cid-shipping-form-container']['children']['cid-shipping-form-fieldset']['children']['shipping_cid_type']['options'];
+
+        foreach ($this->helper->getShippingDocumentTypes() as $k => $v) {
+            $currentOptions[] = ['value' => $k, 'label' => $v];
+        }
+
+        $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']
+        ['shippingAddress']['children']['cid-shipping-form']['children']['cid-shipping-form-container']['children']['cid-shipping-form-fieldset']['children']['shipping_cid_type']['options'] = $currentOptions;
+
+        $jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']
+        ['payment']['children']['cid-billing-form']['children']['cid-billing-form-container']['children']['cid-billing-form-fieldset']['children']['billing_cid_type']['options'] = $currentOptions;
+
+        $logger->info(print_r($currentOptions, true));
         return $jsLayout;
     }
 }

--- a/Plugin/CidConfiguration.php
+++ b/Plugin/CidConfiguration.php
@@ -52,7 +52,7 @@ class CidConfiguration
         ['shippingAddress']['children']['cid-shipping-form']['children']['cid-shipping-form-container']['children']['cid-shipping-form-fieldset']['children']['shipping_cid_type']['options'];
 
         foreach ($this->helper->getShippingDocumentTypes() as $k => $v) {
-            $currentShippingOptions[] = ['value' => $k, 'label' => $v];
+            $currentShippingOptions[] = ['value' => $v, 'label' => $v];
         }
 
         $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']
@@ -62,7 +62,7 @@ class CidConfiguration
         ['payment']['children']['cid-billing-form']['children']['cid-billing-form-container']['children']['cid-billing-form-fieldset']['children']['billing_cid_type']['options'];
 
         foreach ($this->helper->getBillingDocumentTypes() as $k => $v) {
-            $currentBillingOptions[] = ['value' => $k, 'label' => $v];
+            $currentBillingOptions[] = ['value' => $v, 'label' => $v];
         }
 
         $jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']

--- a/Plugin/CidConfiguration.php
+++ b/Plugin/CidConfiguration.php
@@ -37,9 +37,6 @@ class CidConfiguration
         LayoutProcessor $processor,
         array $jsLayout
     ) {
-        $writer = new \Zend\Log\Writer\Stream(BP . '/var/log/oliverio.log');
-        $logger = new \Zend\Log\Logger();
-        $logger->addWriter($writer);
 
         if (!$this->helper->isShippingEnabled()) {
             $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']
@@ -51,20 +48,26 @@ class CidConfiguration
             ['payment']['children']['cid-billing-form']['config']['componentDisabled'] = true;
         }
 
-        $currentOptions = $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']
+        $currentShippingOptions = $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']
         ['shippingAddress']['children']['cid-shipping-form']['children']['cid-shipping-form-container']['children']['cid-shipping-form-fieldset']['children']['shipping_cid_type']['options'];
 
         foreach ($this->helper->getShippingDocumentTypes() as $k => $v) {
-            $currentOptions[] = ['value' => $k, 'label' => $v];
+            $currentShippingOptions[] = ['value' => $k, 'label' => $v];
         }
 
         $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']
-        ['shippingAddress']['children']['cid-shipping-form']['children']['cid-shipping-form-container']['children']['cid-shipping-form-fieldset']['children']['shipping_cid_type']['options'] = $currentOptions;
+        ['shippingAddress']['children']['cid-shipping-form']['children']['cid-shipping-form-container']['children']['cid-shipping-form-fieldset']['children']['shipping_cid_type']['options'] = $currentShippingOptions;
+
+        $currentBillingOptions = $jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']
+        ['payment']['children']['cid-billing-form']['children']['cid-billing-form-container']['children']['cid-billing-form-fieldset']['children']['billing_cid_type']['options'];
+
+        foreach ($this->helper->getBillingDocumentTypes() as $k => $v) {
+            $currentBillingOptions[] = ['value' => $k, 'label' => $v];
+        }
 
         $jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']
-        ['payment']['children']['cid-billing-form']['children']['cid-billing-form-container']['children']['cid-billing-form-fieldset']['children']['billing_cid_type']['options'] = $currentOptions;
+        ['payment']['children']['cid-billing-form']['children']['cid-billing-form-container']['children']['cid-billing-form-fieldset']['children']['billing_cid_type']['options'] = $currentBillingOptions;
 
-        $logger->info(print_r($currentOptions, true));
         return $jsLayout;
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -8,9 +8,19 @@
                     <label>Show on Shipping Step</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="billing_enabled" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="shipping_types" translate="label" type="multiselect" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Shipping Document Types</label>
+                    <source_model>Mugar\CustomerIdentificationDocument\Model\Config\Source\Types</source_model>
+                    <validate>required-entry validate-select</validate>
+                </field>
+                <field id="billing_enabled" translate="label comment" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Show on Payment Step</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="billing_types" translate="label" type="multiselect" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Billing Document Types</label>
+                    <source_model>Mugar\CustomerIdentificationDocument\Model\Config\Source\Types</source_model>
+                    <validate>required-entry validate-select</validate>
                 </field>
             </group>
         </section>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -5,6 +5,8 @@
         	<cid>
         		<shipping_enabled>0</shipping_enabled>
         		<billing_enabled>0</billing_enabled>
+                <shipping_types>1</shipping_types>
+                <billing_types>1</billing_types>
         	</cid>
         </checkout>
     </default>

--- a/view/adminhtml/layout/sales_order_view.xml
+++ b/view/adminhtml/layout/sales_order_view.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="Magento\Backend\Block\Template" name="order_cid_fields" template="Mugar_CustomerIdentificationDocument::order/view/cid_fields.phtml" />
+        <referenceContainer name="content">
+            <block class="Mugar\CustomerIdentificationDocument\Block\Adminhtml\Order\View\CidFields" name="order_cid_fields" template="Mugar_CustomerIdentificationDocument::order/view/cid_fields.phtml" />
+        </referenceContainer>
     </body>
 </page>

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -138,6 +138,7 @@
 																							<item name="label" xsi:type="string">Please select value</item>
 																							<item name="value" xsi:type="string"></item>
 																						</item>
+                                                                                        <!--
 																						<item name="1" xsi:type="array">
 																							<item name="label" xsi:type="string">DNI</item>
 																							<item name="value" xsi:type="string">DNI</item>
@@ -150,6 +151,7 @@
 																							<item name="label" xsi:type="string">Passport</item>
 																							<item name="value" xsi:type="string">Passport</item>
 																						</item>
+																						-->
 																					</item>
 																					<item name="provider" xsi:type="string">checkoutProvider</item>
 																					<item name="dataScope" xsi:type="string">cidBillingForm.billing_cid_type</item>

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -45,7 +45,7 @@
 																							<item name="label" xsi:type="string">Please select value</item>
 																							<item name="value" xsi:type="string"></item>
 																						</item>
-																						<item name="1" xsi:type="array">
+																						<!--<item name="1" xsi:type="array">
 																							<item name="label" xsi:type="string">DNI</item>
 																							<item name="value" xsi:type="string">DNI</item>
 																						</item>
@@ -57,6 +57,7 @@
 																							<item name="label" xsi:type="string">Passport</item>
 																							<item name="value" xsi:type="string">Passport</item>
 																						</item>
+																						-->
 																					</item>
 																					<item name="provider" xsi:type="string">checkoutProvider</item>
 																					<item name="dataScope" xsi:type="string">cidShippingForm.shipping_cid_type</item>
@@ -121,7 +122,7 @@
                                                                         <item name="cid-billing-form-fieldset" xsi:type="array">
                                                                             <item name="component" xsi:type="string">uiComponent</item>
                                                                             <item name="displayArea" xsi:type="string">cid-billing-form-fields</item>
-                                                                            
+
                                                                             <item name="children" xsi:type="array">
 																				<item name="billing_cid_type" xsi:type="array">
 																					<item name="component" xsi:type="string">Magento_Ui/js/form/element/select</item>
@@ -158,7 +159,7 @@
 																					    <item name="half-row" xsi:type="boolean">true</item>
 																						<item name="half-row-left" xsi:type="boolean">true</item>
 																					</item>
-																				</item>                                                                                
+																				</item>
                                                                                 <item name="billing_cid_number" xsi:type="array">
                                                                                     <item name="component" xsi:type="string">Magento_Ui/js/form/element/abstract</item>
                                                                                     <item name="config" xsi:type="array">

--- a/view/frontend/layout/sales_order_view.xml
+++ b/view/frontend/layout/sales_order_view.xml
@@ -2,7 +2,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Mugar\CustomerIdentificationDocument\Block\Order\CidFields" as="ordercidfields" name="sales.order.cidfields" after="sales.order.info"/>
+            <block class="Mugar\CustomerIdentificationDocument\Block\Order\View\CidFields" as="ordercidfields" name="sales.order.cidfields" after="sales.order.info"  />
         </referenceContainer>
     </body>
 </page>

--- a/view/frontend/web/js/view/checkout/cid-billing-form.js
+++ b/view/frontend/web/js/view/checkout/cid-billing-form.js
@@ -17,9 +17,9 @@ define([
     return Component.extend({
         cidFields: ko.observable(null),
         formDatax: formData.cidBillingFieldsData,
-        
-        
-    
+
+
+
         initialize: function () {
             var self = this;
             this._super();
@@ -33,14 +33,14 @@ define([
             this.cidFields.subscribe(function(change){
                 self.formData(change);
             });
-            
-            
+
+
 
             return this;
         },
-        
+
         onFormSubmit: function () {
-            console.log('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+            console.log('onFormSubmit');
         },
 
         onFormChange: function () {
@@ -59,9 +59,9 @@ define([
                 var url;
 
                 if (isCustomer) {
-                    url = urlBuilder.createUrl('/carts/mine/set-order-cid-fields', {});
+                    url = urlBuilder.createUrl('/carts/mine/set-order-cid-billing-fields', {});
                 } else {
-                    url = urlBuilder.createUrl('/guest-carts/:cartId/set-order-cid-billing-field', {cartId: quoteId});
+                    url = urlBuilder.createUrl('/guest-carts/:cartId/set-order-cid-billing-fields', {cartId: quoteId});
                 }
 
                 var payload = {
@@ -69,6 +69,7 @@ define([
                     cidFields: formData
                 };
                 var result = true;
+                console.log(url);
                 $.ajax({
                     url: urlFormatter.build(url),
                     data: JSON.stringify(payload),


### PR DESCRIPTION
### Descripción
Se agrego al system las opciones de documentos para shipping y billing

### Issues relacionados
holamugar/module-customer-identification-document#13: Hacer editable el source de tipos de documento

### Escenarios de testing manual
Backend
1. admin login
2. Stores > Configuration :: Sales > Checkout :: Customer Identification Document
3. Seleccionar "Shipping Document Types" que se quieran mostrar en frontend (por defecto la opcion DNI debe aparecer seleccionada)
4. Seleccionar "Billing Document Types" que se quieran mostrar en frontend (por defecto la opcion DNI debe aparecer seleccionada)
5. Guardar cambios y limpiar Mage cache.
6. Verificar que las opciones seleccionadas fueron guardadas correctamente

Frontend
1. Agregar cualquier producto al cart
2. Iniciar checkout
3. Verificar que las opciones de documento en el paso "Shipping" corresponden a las configuradas anteriormente en el backend
4. Completar el formulario y continuar al paso "Review & Payments"
5. Verificar que las opciones de documento en el paso "Review & Payments" corresponden a las configuradas anteriormente en el backend
6. Completar la orden y verificar que la informacion de documentos (shipping y billing) persiste en la DB
