### PR TITLE
#28 Correccion en la cadena de validación

### DIFF
--- a/view/frontend/web/js/view/shipping-mixin.js
+++ b/view/frontend/web/js/view/shipping-mixin.js
@@ -1,156 +1,28 @@
-
 define([
     'jquery',
-    'underscore',
-    'Magento_Ui/js/form/form',
-    'ko',
-    'Magento_Customer/js/model/customer',
-    'Magento_Customer/js/model/address-list',
-    'Magento_Checkout/js/model/address-converter',
-    'Magento_Checkout/js/model/quote',
-    'Magento_Checkout/js/action/create-shipping-address',
-    'Magento_Checkout/js/action/select-shipping-address',
-    'Magento_Checkout/js/model/shipping-rates-validator',
-    'Magento_Checkout/js/model/shipping-address/form-popup-state',
-    'Magento_Checkout/js/model/shipping-service',
-    'Magento_Checkout/js/action/select-shipping-method',
-    'Magento_Checkout/js/model/shipping-rate-registry',
-    'Magento_Checkout/js/action/set-shipping-information',
-    'Magento_Checkout/js/model/step-navigator',
-    'Magento_Ui/js/modal/modal',
-    'Magento_Checkout/js/model/checkout-data-resolver',
-    'Magento_Checkout/js/checkout-data',
-    'uiRegistry',
-    'mage/translate',
-    'Magento_Checkout/js/model/shipping-rate-service'
-], function (
-    $,
-    _,
-    Component,
-    ko,
-    customer,
-    addressList,
-    addressConverter,
-    quote,
-    createShippingAddress,
-    selectShippingAddress,
-    shippingRatesValidator,
-    formPopUpState,
-    shippingService,
-    selectShippingMethodAction,
-    rateRegistry,
-    setShippingInformationAction,
-    stepNavigator,
-    modal,
-    checkoutDataResolver,
-    checkoutData,
-    registry,
-    $t
-) {
+    'underscore'
+], function ($, _) {
     'use strict';
 
-    var mixin = {
-
-        defaults: {
-            template: 'Mugar_CustomerIdentificationDocument/shipping'
-        },
-        validateCidShippingForm: function () {
-            this.source.set('params.invalid', false);
-            this.source.trigger('cidShippingForm.data.validate');
-            return this.source.get('params.invalid');
-        },
-
-        validateShippingInformation: function () {
-            var shippingAddress,
-                addressData,
-                loginFormSelector = 'form[data-role=email-with-possible-login]',
-                emailValidationResult = customer.isLoggedIn(),
-                field,
-                country = registry.get(this.parentName + '.shippingAddress.shipping-address-fieldset.country_id'),
-                countryIndexedOptions = country.indexedOptions,
-                option = countryIndexedOptions[quote.shippingAddress().countryId],
-                messageContainer = registry.get('checkout.errors').messageContainer;
-
-            if (!quote.shippingMethod()) {
-                this.errorValidationMessage(
-                    $t('The shipping method is missing. Select the shipping method and try again.')
-                );
-
-                return false;
-            }
-
-            if (!customer.isLoggedIn()) {
-                $(loginFormSelector).validation();
-                emailValidationResult = Boolean($(loginFormSelector + ' input[name=username]').valid());
-            }
-
-            if (this.isFormInline) {
+    return function (target) {
+        return target.extend({
+            defaults: {
+                template: 'Mugar_CustomerIdentificationDocument/shipping'
+            },
+            validateCidShippingForm: function () {
                 this.source.set('params.invalid', false);
+                this.source.trigger('cidShippingForm.data.validate');
+                return !this.source.get('params.invalid');
+            },
 
-                this.triggerShippingDataValidateEvent();
-
-                if (emailValidationResult &&
-                    this.source.get('params.invalid') ||
-                    !quote.shippingMethod()['method_code'] ||
-                    !quote.shippingMethod()['carrier_code']
-                ) {
-                    this.focusInvalid();
-
+            validateShippingInformation: function () {
+                if (this._super() === false) {
                     return false;
                 }
 
-                shippingAddress = quote.shippingAddress();
-                addressData = addressConverter.formAddressDataToQuoteAddress(
-                    this.source.get('shippingAddress')
-                );
-
-                //Copy form data to quote shipping address object
-                for (field in addressData) {
-                    if (addressData.hasOwnProperty(field) &&  //eslint-disable-line max-depth
-                        shippingAddress.hasOwnProperty(field) &&
-                        typeof addressData[field] != 'function' &&
-                        _.isEqual(shippingAddress[field], addressData[field])
-                    ) {
-                        shippingAddress[field] = addressData[field];
-                    } else if (typeof addressData[field] != 'function' &&
-                        !_.isEqual(shippingAddress[field], addressData[field])) {
-                        shippingAddress = addressData;
-                        break;
-                    }
-                }
-
-                if (customer.isLoggedIn()) {
-                    shippingAddress['save_in_address_book'] = 1;
-                }
-                selectShippingAddress(shippingAddress);
-            } else if (customer.isLoggedIn() &&
-                option &&
-                option['is_region_required'] &&
-                !quote.shippingAddress().region
-            ) {
-                messageContainer.addErrorMessage({
-                    message: $t('Please specify a regionId in shipping address.')
-                });
-
-                return false;
+                /* validate cid fields */
+                return this.validateCidShippingForm();
             }
-
-            if (!emailValidationResult) {
-                $(loginFormSelector + ' input[name=username]').focus();
-
-                return false;
-            }
-
-            /* validate cid fields */
-            if(this.validateCidShippingForm()){
-            	return false;
-            }
-
-            return true;
-        }
-    };
-
-    return function (target) {
-        return target.extend(mixin);
+        });
     };
 });


### PR DESCRIPTION
Agrego compatibilidad con otros módulos que usen mixin sobre view/shipping.js

### Descripción

### Issues relacionados (si fuera aplicable)
1. holamugar/module-customer-identification-document#28: Error en cadena de validación

### Escenarios de testing manual 
Previo a esta correccion
1. Instalar el modulo de oca (https://github.com/gento-arg/magento-oca)
2. En el checkout elegir envio a sucursal. En este caso el modulo de oca usa un mixin para validar que se seleccione una sucursal
3. No seleccionar ninguna sucursal
4. Validar que se pasa al pago sin sucursal 

Posterior a la correccion:
El paso 4 no será posible porque entrará la validación de sucursal como corresponde.
