### PR TITLE
Keep data from quote to order

### DIFF
--- a/Observer/Adminhtml/AddCidFieldsToQuote.php
+++ b/Observer/Adminhtml/AddCidFieldsToQuote.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Customer Identification Document
+ *
+ * @category   Mugar
+ * @package    Mugar_CustomerIdentificationDocument
+ * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @author     Mugar (https://www.mugar.io/)
+ *
+ */
+
+namespace Mugar\CustomerIdentificationDocument\Observer\Adminhtml;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Mugar\CustomerIdentificationDocument\Api\Data\CidFieldsInterface;
+
+class AddCidFieldsToQuote implements ObserverInterface
+{
+    public function execute(Observer $observer)
+    {
+        $quote = $observer->getEvent()->getQuote();
+        $order = $observer->getEvent()->getOrder();
+
+        $quote->setData(
+            CidFieldsInterface::SHIPPING_CID_TYPE,
+            $order->getData(CidFieldsInterface::SHIPPING_CID_TYPE)
+        );
+        $quote->setData(
+            CidFieldsInterface::SHIPPING_CID_NUMBER,
+            $order->getData(CidFieldsInterface::SHIPPING_CID_NUMBER)
+        );
+        $quote->setData(
+            CidFieldsInterface::BILLING_CID_TYPE,
+            $order->getData(CidFieldsInterface::BILLING_CID_TYPE)
+        );
+        $quote->setData(
+            CidFieldsInterface::BILLING_CID_NUMBER,
+            $order->getData(CidFieldsInterface::BILLING_CID_NUMBER)
+        );
+    }
+}

--- a/etc/adminhtml/events.xml
+++ b/etc/adminhtml/events.xml
@@ -12,8 +12,8 @@
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
-    <event name="sales_model_service_quote_submit_before">
-        <observer name="checkout_cid_fields_add_to_order"
-                  instance="Mugar\CustomerIdentificationDocument\Observer\AddCidFieldsToOrder" />
+    <event name="sales_convert_order_to_quote">
+        <observer name="Mugar\CustomerIdentificationDocument\Observer\Adminhtml\AddCidFieldsToQuote"
+                  instance="Mugar\CustomerIdentificationDocument\Observer\Adminhtml\AddCidFieldsToQuote" />
     </event>
 </config>


### PR DESCRIPTION
### Descripción

Just keep the same data that the customer set when create the order, this allow to admin users to edit orders without losing the doctype and docnumber